### PR TITLE
fix(tldraw): treat loopback hosts as development

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
 import { resolve } from "path"
+import { promises as fs } from "fs";
 import { defineConfig, loadEnv } from "vite"
 import { viteStaticCopy } from "vite-plugin-static-copy"
 import livereload from "rollup-plugin-livereload"
@@ -81,6 +82,7 @@ export default defineConfig({
         },
         rollupOptions: {
             plugins: [
+                patchTldrawLoopbackDev(),
                 ...(isDev ? [
                     livereload(outputDir),
                     {
@@ -176,6 +178,41 @@ function cleanupDistFiles(options: { patterns: string[], distDir: string }) {
                         console.error(`Failed to clean up ${file}:`, error);
                     }
                 }
+            }
+        }
+    };
+}
+
+/**
+ * 让 tldraw 在本地 loopback 地址下也视为开发环境。
+ *
+ * SiYuan 3.7 dev14 会以 https://127.0.0.1 打开插件页面，
+ * 而 tldraw 默认只把 localhost 视作开发环境，导致 Hobby License
+ * 被当成生产环境校验。这个构建后补丁只替换 tldraw 的开发判断，
+ * 不改 SiYuan 源码。
+ */
+function patchTldrawLoopbackDev() {
+    const targetPattern = /window\.location\.hostname===["']localhost["']/g;
+    const replacement = '["localhost","127.0.0.1","::1"].includes(window.location.hostname.toLowerCase())';
+
+    return {
+        name: 'patch-tldraw-loopback-dev',
+        enforce: 'post' as const,
+        async writeBundle() {
+            const filePath = resolve(__dirname, outputDir, 'index.js');
+
+            try {
+                const code = await fs.readFile(filePath, 'utf8');
+                const patched = code.replace(targetPattern, replacement);
+
+                if (patched !== code) {
+                    await fs.writeFile(filePath, patched, 'utf8');
+                    console.log(`[patch-tldraw-loopback-dev] patched ${filePath}`);
+                } else {
+                    console.warn(`[patch-tldraw-loopback-dev] no tldraw localhost check found in ${filePath}`);
+                }
+            } catch (error) {
+                console.warn(`[patch-tldraw-loopback-dev] failed for ${filePath}`, error);
             }
         }
     };


### PR DESCRIPTION
标题：fix(tldraw): 兼容 https://127.0.0.1 的开发环境

### 问题
SiYuan 3.7 dev14 在 `https://127.0.0.1` 下打开插件页面时，tldraw 只把 `localhost` 识别为开发环境，导致 Hobby License 被按生产环境校验并报错。

### 修改
在插件构建流程中加入一个后处理补丁，将 tldraw 的开发环境判断扩展为 `localhost`、`127.0.0.1` 和 `::1`。

### 说明
- 这个修复会在打包产物中生效，兼容本地 loopback 地址